### PR TITLE
Fix contact link and remove unused script

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,7 @@
             <div class="col-md-12 text-center">
               <p class="mb-0">
                 <span class="icon-mail_outline d-block h4 text-primary"></span>
-                <span><a href=mailto:"maximo@babun.com">maximo@babun.com</a></span>
+                <span><a href="mailto:maximo@babun.com">maximo@babun.com</a></span>
               </p>
             </div>
 
@@ -357,7 +357,6 @@
     <script src="js/jquery.fancybox.min.js"></script>
     <script src="js/jquery.sticky.js"></script>
     <script src="js/isotope.pkgd.min.js"></script>
-    <script src="js/collapsable.js"></script>
 
     <script src="js/main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- fix the `mailto:` link in the contact section so it actually opens an email draft
- remove reference to missing `collapsable.js` script

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f8323b308832981e8a98107d2862e